### PR TITLE
Accept RPG Maker MZ .rmmzsave files (pako/zlib + LZ-String)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you find this tool useful, please consider supporting us:
 
 ## Features
 
-- Open and edit `.rpgsave` files.
+- Open and edit RPG Maker MV (`.rpgsave`, LZ-String) and MZ (`.rmmzsave`, pako/zlib) save files.
 - Modify game data such as party, items, switches, and variables.
 - Supports light and dark modes.
 - Easy-to-use interface with file selection and reload options.
@@ -70,7 +70,7 @@ If you find this tool useful, please consider supporting us:
 ## Usage
 
 1. Launch the application.
-2. Click on the file icon to open a `.rpgsave` file.
+2. Click on the file icon to open a `.rpgsave` (MV) or `.rmmzsave` (MZ) file.
 3. Edit the desired data using the available sections in the sidebar.
 4. Save your changes or reload the file if needed.
 

--- a/src/context/ContentContext.tsx
+++ b/src/context/ContentContext.tsx
@@ -4,6 +4,7 @@ import { ItemData } from '../types/Item';
 import { SystemData } from '../types/System';
 import { ArmorData } from '../types/Armo';
 import { SaveData } from '../types/SaveData';
+import { SaveCodec } from '../utils/rpgsaveUtils';
 
 // Define interfaces for Content and ContentContext
 export interface ContentType {
@@ -17,6 +18,7 @@ export interface ContentType {
   filePath?: string;
   fileName?: string;
   gameName?: string;
+  saveCodec?: SaveCodec;
 }
 
 interface ContentContextType {

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -2,10 +2,10 @@ import { useCallback } from 'react';
 import { ContentType, useContent } from '../context/ContentContext';
 import { readFile, selectFile, writeFile } from '../utils/fileUtils';
 import { exists, readTextFile } from '@tauri-apps/plugin-fs';
-import { decodeRpgsave, encodeRpgsave } from '../utils/rpgsaveUtils';
+import { decodeRpgsave, encodeRpgsave, preferredCodecForPath } from '../utils/rpgsaveUtils';
+import { fileNameFromPath, isRpgSavePath } from '../utils/saveExtensions';
 import { toast } from 'react-toastify';
 import { rpgSaveToSaveData } from '../utils/saveDataUtils';
-import { RPGSave } from '../types/RPGSave';
 import { dirname, join } from '@tauri-apps/api/path';
 
 
@@ -14,23 +14,25 @@ export const useFileUpload = () => {
 
   const handleReadFile = useCallback(async (filePath: string) => {
     try {
-      const fileContent = await readFile(filePath);
-      if (!filePath.endsWith('.rpgsave')) {
-        return errorNotify('Invalid file type! Please upload a .rpgsave file.');
+      if (!isRpgSavePath(filePath)) {
+        return errorNotify('Invalid file type! Please upload a .rpgsave or .rmmzsave file.');
       }
+      const fileContent = await readFile(filePath);
 
-      const decodedContent: RPGSave = decodeRpgsave(fileContent);
-      const decodedContent2: RPGSave = decodeRpgsave(fileContent);
+      const preferred = preferredCodecForPath(filePath);
+      const decoded = await decodeRpgsave(fileContent, preferred);
+      const decodedOrigin = await decodeRpgsave(fileContent, decoded.codec);
       const gameName = getNameOfGame(filePath);
 
       const contentData: ContentType = {
         ...content,
         oldSaveData: gameName !== content?.gameName ? undefined : content?.originSaveData,
-        saveData: rpgSaveToSaveData(decodedContent),
-        originSaveData: rpgSaveToSaveData(decodedContent2),
-        fileName: filePath.split('\\').pop() || '',
+        saveData: rpgSaveToSaveData(decoded.data),
+        originSaveData: rpgSaveToSaveData(decodedOrigin.data),
+        fileName: fileNameFromPath(filePath),
         filePath,
         gameName,
+        saveCodec: decoded.codec,
         itemData: await loadJsonData(filePath, 'Items'),
         systemData: await loadJsonData(filePath, 'System'),
         weaponsData: await loadJsonData(filePath, 'Weapons'),
@@ -91,17 +93,20 @@ export const useReload = () => {
 
   const handleReadFile = useCallback(async (filePath: string) => {
     try {
-      const fileContent = await readFile(filePath);
-      if (filePath.endsWith('.rpgsave')) {
-        const decodedContent: RPGSave = decodeRpgsave(fileContent);
-        const decodedContent2: RPGSave = decodeRpgsave(fileContent);
-        setContent((prev: any) => ({
-          ...prev,
-          oldSaveData: prev?.originSaveData || undefined,
-          saveData: rpgSaveToSaveData(decodedContent),
-          originSaveData: rpgSaveToSaveData(decodedContent2),
-        }));
+      if (!isRpgSavePath(filePath)) {
+        return errorNotify('Invalid file type! Please upload a .rpgsave or .rmmzsave file.');
       }
+      const fileContent = await readFile(filePath);
+      const preferred = preferredCodecForPath(filePath);
+      const decoded = await decodeRpgsave(fileContent, preferred);
+      const decodedOrigin = await decodeRpgsave(fileContent, decoded.codec);
+      setContent((prev: any) => ({
+        ...prev,
+        oldSaveData: prev?.originSaveData || undefined,
+        saveData: rpgSaveToSaveData(decoded.data),
+        originSaveData: rpgSaveToSaveData(decodedOrigin.data),
+        saveCodec: decoded.codec,
+      }));
       successNotify('File Reloaded!');
     } catch (error) {
       errorNotify(`Error Reloading File Save! \n${error}`);
@@ -124,7 +129,7 @@ export const useSave = () => {
   const save = useCallback(async () => {
     try {
       if (content.filePath) {
-        const encodedContent = encodeRpgsave(JSON.stringify(content.saveData));
+        const encodedContent = await encodeRpgsave(JSON.stringify(content.saveData), content.saveCodec ?? 'lzstring');
         await writeFile(content.filePath, encodedContent);
         successNotify('File Saved!')
       }
@@ -135,7 +140,7 @@ export const useSave = () => {
 
     }
 
-  }, [content.filePath, content.saveData]);
+  }, [content.filePath, content.saveData, content.saveCodec]);
 
   return save;
 };
@@ -143,11 +148,10 @@ export const useSave = () => {
 
 const getJsonFilePath = async (originalPath: string, fileName: string): Promise<string> => {
   try {
-    // Get the parent directory of the .rpgsave file (e.g. 'D:\Gamess\AmongUs\Winter Memories (Kagura v1.08)\www')
+    // Parent of save/ is www/ (MV) or the game root (MZ). Both keep data/*.json there.
     const saveDir = await dirname(originalPath);
-    const wwwDir = await dirname(saveDir);
-    // Join: wwwDir + '/data' + fileName.json (cross-platform)
-    const jsonPath = await join(wwwDir, 'data', `${fileName}.json`);
+    const gameOrWwwDir = await dirname(saveDir);
+    const jsonPath = await join(gameOrWwwDir, 'data', `${fileName}.json`);
     
     return jsonPath;
   } catch (error) {
@@ -156,11 +160,13 @@ const getJsonFilePath = async (originalPath: string, fileName: string): Promise<
   }
 };
 function getNameOfGame(originalPath: string): string {
-  const pathParts = originalPath.split('\\');
-  pathParts.pop() // 'file1.rpgsave'
-  pathParts.pop() // 'save'
-  pathParts.pop() // 'www'
-  const gameName = pathParts.pop();
+  const pathParts = originalPath.split(/[/\\]/).filter(Boolean);
+  pathParts.pop(); // file1.rpgsave / file1.rmmzsave
+  pathParts.pop(); // save
+  let gameName = pathParts.pop(); // www (MV) or game folder (MZ)
+  if (gameName && gameName.toLowerCase() === 'www') {
+    gameName = pathParts.pop();
+  }
   console.log(gameName);
 
   if (gameName) {
@@ -169,6 +175,7 @@ function getNameOfGame(originalPath: string): string {
   warningNotify('Could not determine game name from file path.');
   return 'Unknown Game';
 }
+
 const successNotify = (text: string) => {
   toast.success(text, {
     position: "bottom-right",

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,5 +1,6 @@
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+import { RPG_SAVE_EXTENSIONS } from './saveExtensions';
 
 /**
  * Mở hộp thoại chọn file và trả về đường dẫn file đã chọn.
@@ -7,7 +8,7 @@ import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 export async function selectFile(): Promise<string | null> {
   const filePath = await open({
     multiple: false, // Chỉ chọn một file
-    filters: [{ name: 'RPG Save Files', extensions: ['rpgsave'] }], // Chỉ chấp nhận file .rpgsave
+    filters: [{ name: 'RPG Maker Save Files', extensions: [...RPG_SAVE_EXTENSIONS] }],
   });
   return filePath as string | null;
 }
@@ -28,7 +29,7 @@ export const saveFile = async (): Promise<string | null> => {
     const filePath = await save({
       defaultPath: 'savefile.rpgsave', // Đặt tên file mặc định
       filters: [
-        { name: 'RPG Save Files', extensions: ['rpgsave'] },
+        { name: 'RPG Maker Save Files', extensions: [...RPG_SAVE_EXTENSIONS] },
         { name: 'All Files', extensions: ['*'] }
       ]
     });

--- a/src/utils/rpgsaveUtils.ts
+++ b/src/utils/rpgsaveUtils.ts
@@ -1,36 +1,80 @@
 import LZString from 'lz-string';
 import { RPGSave } from '../types/RPGSave';
 
-/**
- * Giải nén và phân tích dữ liệu từ file .rpgsave
- * @param {string} save - Dữ liệu mã hóa base64
- * @returns {string} - Dữ liệu JSON đã giải nén và định dạng
- */
-export function decodeRpgsave(save: string): RPGSave {
+/** MV = LZ-String Base64; official MZ = pako/zlib written as a UTF-8 binary string. */
+export type SaveCodec = 'lzstring' | 'pako';
+
+function tryLzString(save: string): RPGSave | null {
   try {
     const decoded = LZString.decompressFromBase64(save);
-    if (!decoded) throw new Error('Failed to decompress data');
-    const parsed = JSON.parse(decoded);
-    return parsed; // Định dạng JSON đẹp hơn
-  } catch (error) {
-    console.error('Error decoding .rpgsave file:', error);
-    throw error;
+    if (!decoded) return null;
+    return JSON.parse(decoded);
+  } catch {
+    return null;
   }
 }
 
-/**
- * Nén và mã hóa dữ liệu cho file .rpgsave
- * @param {string} save - Dữ liệu JSON để mã hóa
- * @returns {string} - Dữ liệu mã hóa base64
- */
-export function encodeRpgsave(save: string): string {
-  try {
-    const parsed = JSON.parse(save);
-    const minified = JSON.stringify(parsed, null, 0); // Loại bỏ khoảng trắng không cần thiết
-    const encoded = LZString.compressToBase64(minified);
-    return encoded;
-  } catch (error) {
-    console.error('Error encoding .rpgsave file:', error);
-    throw error;
+function binaryStringToBytes(save: string): Uint8Array {
+  const compressed = new Uint8Array(save.length);
+  for (let i = 0; i < save.length; i++) {
+    compressed[i] = save.charCodeAt(i) & 0xff;
   }
+  return compressed;
+}
+
+function bytesToBinaryString(bytes: Uint8Array): string {
+  const chunk = 0x2000;
+  let result = '';
+  for (let i = 0; i < bytes.length; i += chunk) {
+    result += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return result;
+}
+
+async function tryPako(save: string): Promise<RPGSave | null> {
+  try {
+    if (typeof DecompressionStream === 'undefined') return null;
+    const compressed = binaryStringToBytes(save);
+    const stream = new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate'));
+    const jsonStr = await new Response(stream).text();
+    if (!jsonStr) return null;
+    return JSON.parse(jsonStr);
+  } catch {
+    return null;
+  }
+}
+
+async function deflateZlib(text: string): Promise<string> {
+  const stream = new Blob([text]).stream().pipeThrough(new CompressionStream('deflate'));
+  const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+  return bytesToBinaryString(bytes);
+}
+
+/**
+ * Decode an RPG Maker MV (.rpgsave) or MZ (.rmmzsave) payload.
+ * Tries the preferred codec first, then the other, so mislabeled files still open.
+ */
+export async function decodeRpgsave(save: string, preferred: SaveCodec = 'lzstring'): Promise<{ data: RPGSave; codec: SaveCodec }> {
+  const order: SaveCodec[] = preferred === 'pako' ? ['pako', 'lzstring'] : ['lzstring', 'pako'];
+  for (const codec of order) {
+    const data = codec === 'lzstring' ? tryLzString(save) : await tryPako(save);
+    if (data) return { data, codec };
+  }
+  throw new Error('Failed to decompress save data (tried LZ-String and pako/zlib)');
+}
+
+/**
+ * Encode save JSON using the same codec the file was opened with.
+ */
+export async function encodeRpgsave(save: string, codec: SaveCodec = 'lzstring'): Promise<string> {
+  const parsed = JSON.parse(save);
+  const minified = JSON.stringify(parsed, null, 0);
+  if (codec === 'pako') {
+    return deflateZlib(minified);
+  }
+  return LZString.compressToBase64(minified);
+}
+
+export function preferredCodecForPath(filePath: string): SaveCodec {
+  return filePath.toLowerCase().endsWith('.rmmzsave') ? 'pako' : 'lzstring';
 }

--- a/src/utils/saveExtensions.ts
+++ b/src/utils/saveExtensions.ts
@@ -1,0 +1,11 @@
+/** LZ-String + Base64 save formats used by stock RPG Maker MV / MZ. */
+export const RPG_SAVE_EXTENSIONS = ['rpgsave', 'rmmzsave'] as const;
+
+export function isRpgSavePath(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  return RPG_SAVE_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`));
+}
+
+export function fileNameFromPath(filePath: string): string {
+  return filePath.split(/[/\\]/).pop() || '';
+}


### PR DESCRIPTION
## Summary
- Fixes #7 for the extensions that actually share this editor's payload: `.rpgsave` (MV, LZ-String) and `.rmmzsave` (MZ, official pako/zlib written as a UTF-8 binary string).
- Open/save dialogs and the reload path now accept both suffixes (case-insensitive). Reload no longer reports success when the file was skipped.
- Decode tries the extension's preferred codec first, then the other, so a mislabeled file can still open. Save writes back with the codec that succeeded.
- Game name no longer assumes a `www/` folder (MZ keeps `save/` next to `data/`).

Not included: generic `.sav`. That extension is used by many unrelated engines; accepting it here would only produce cryptic decompress errors.

## Test plan
- [ ] Open a stock MV `file1.rpgsave` — party/items/switches still load and save as LZ-String.
- [ ] Open a stock MZ `file1.rmmzsave` — file appears in the picker, gold/variables edit, and the game still loads the rewritten file.
- [ ] Reload an MZ save after an external change; toast should only succeed when decode worked.
- [ ] Confirm a `.sav` / `.txt` is still rejected.